### PR TITLE
fixed 'Unit tomcat9.service could not be found'

### DIFF
--- a/userdata/tomcat_ubuntu.sh
+++ b/userdata/tomcat_ubuntu.sh
@@ -2,4 +2,4 @@
 sudo apt update
 sudo apt upgrade -y
 sudo apt install openjdk-11-jdk -y
-sudo apt install tomcat9 tomcat9-admin tomcat9-docs tomcat9-common git -y
+sudo apt install tomcat10 tomcat10-admin tomcat10-docs tomcat10-common git -y


### PR DESCRIPTION
### Unit tomcat9.service could not be found

I was working on an aws lift and shift project and faced the issue of "Unit tomcat9.service could not be found" After research, I finally found that the problem is with tomcat9. So I upgraded it to tomcat10 and the issue was resolved.