### PR TITLE
Update jenkins-setup.sh

### DIFF
--- a/userdata/jenkins-setup.sh
+++ b/userdata/jenkins-setup.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 sudo apt update
-sudo apt install openjdk-11-jdk -y
+sudo apt install openjdk-17-jdk -y
 sudo apt install maven wget unzip -y
 
 curl -fsSL https://pkg.jenkins.io/debian-stable/jenkins.io-2023.key | sudo tee \


### PR DESCRIPTION
Because, Jenkins has deprecated the java 11 version, 17 works fine.